### PR TITLE
finish chapter-12:Password Reset

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,7 +31,7 @@ textarea {
 .center {
   text-align: center;
   h1 {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
   }
 }
 

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,62 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, only: [ :edit, :update ]
+  before_action :valid_user, only: [ :edit, :update ]
+  before_action :check_expiration, only: [ :edit, :update ]
+
+  def new
+  end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = "Email sent with password reset instructions"
+      redirect_to root_url
+    else
+      flash.now[:danger] = "Email address not found"
+      render "new", status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, "can't be empty")
+      render "edit", status: :unprocessable_entity
+    elsif @user.update(user_params)
+      @user.update_attribute(:reset_digest, nil)
+      log_in @user
+      flash[:success] = "Password has been reset."
+      redirect_to @user
+    else
+      render "edit", status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:password, :password_confirmation)
+    end
+
+    def get_user
+      @user = User.find_by(email: params[:email])
+    end
+
+    def valid_user
+      unless @user && @user.activated? &&
+              @user.authenticated?(:reset, params[:id])
+        redirect_to root_url
+      end
+    end
+
+    def check_expiration
+      if @user.password_reset_expired?
+        flash[:danger] = "Password reset has expired."
+        redirect_to new_password_reset_url
+      end
+    end
+end

--- a/app/helpers/password_resets_helper.rb
+++ b/app/helpers/password_resets_helper.rb
@@ -1,0 +1,2 @@
+module PasswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,8 +14,8 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.password_reset.subject
   #
-  def password_reset
-    @greeting = "Hi"
-    mail to: "to@example.org"
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: "Password reset"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
   before_save :downcase_email
   before_create :create_activation_digest
 
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   validates :email,
             presence: true,
             length: { maximum: 255 },
-            format: { with: VALID_EMAIL_REGEX },
+                  format: { with: VALID_EMAIL_REGEX },
             uniqueness: true
   validates :password,
             presence: true,
@@ -60,11 +60,27 @@ class User < ApplicationRecord
     UserMailer.account_activation(self).deliver_now
   end
 
+  # Sets the password reset attributes.
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # Sends password reset email.
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  # Returns true if a password reset has expired.
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
+  end
+
   private
 
   def downcase_email
     self.email = email.downcase
-  end
+    end
 
   # Creates and assigns the activation token and digest.
   def create_activation_digest

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,20 @@
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @user, url: password_reset_path(params[:id])) do |f| %>
+      <%= render 'shared/error_messages', object: @user %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit "Update password", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, "Forgot password") %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_resets_path, scope: :password_reset, local: true) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,12 +3,13 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(url: login_path, scope: :session) do |f| %>
+    <%= form_with(url: login_path, scope: :session, local: true) do |f| %>
 
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,13 @@
-<h1>User#password_reset</h1>
+<% provide(:title, 'Password reset') %>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to "Reset password", edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.
 </p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,3 +1,12 @@
 User#password_reset
 
 <%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb
+
+To reset your password click the link below:
+
+<%= edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+This link will expire in two hours.
+
+If you did not request your password to be reset, please ignore this email and
+your password will stay as it is.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
+  get "password_resets/new"
+  get "password_resets/edit"
   root "static_pages#home"
   resources :users
   resources :account_activations, only: [ :edit ]
+  resources :password_resets, only: [ :new, :create, :edit, :update ]
 
   get  "/help",    to: "static_pages#help"
   get  "/about",   to: "static_pages#about"

--- a/db/migrate/20250619143507_add_reset_to_users.rb
+++ b/db/migrate/20250619143507_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_19_024040) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_19_143507) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -22,6 +22,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_024040) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 end

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class PasswordResetsTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+    @user = users(:michael)
+  end
+
+  test "password resets" do
+    get new_password_reset_path
+    assert_template "password_resets/new"
+    assert_select "input[name=?]", "password_reset[email]"
+    # Invalid email
+    post password_resets_path, params: { password_reset: { email: "" } }
+    assert_not flash.empty?
+    assert_template "password_resets/new"
+    # Valid email
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+    assert_not_equal @user.reset_digest, @user.reload.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+    # Password reset form
+    user = assigns(:user)
+    # Wrong email
+    get edit_password_reset_path(user.reset_token, email: "")
+    assert_redirected_to root_url
+    # Inactive user
+    user.toggle!(:activated)
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_redirected_to root_url
+    user.toggle!(:activated)
+    # Right email, wrong token
+    get edit_password_reset_path("wrong token", email: user.email)
+    assert_redirected_to root_url
+    # Right email, right token
+    get edit_password_reset_path(user.reset_token, email: user.email)
+    assert_template "password_resets/edit"
+    assert_select "input[name=email][type=hidden][value=?]", user.email
+    # Invalid password & confirmation
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                   user: { password:              "foobaz",
+                          password_confirmation: "barquux" } }
+    assert_select "div#error_explanation"
+    # Empty password
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                   user: { password:              "",
+                          password_confirmation: "" } }
+    assert_select "div#error_explanation"
+    # Valid password & confirmation
+    patch password_reset_path(user.reset_token),
+          params: { email: user.email,
+                   user: { password:              "foobaz",
+                          password_confirmation: "foobaz" } }
+    assert_nil user.reload.reset_digest
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to user
+  end
+
+  test "expired token" do
+    get new_password_reset_path
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+
+    @user = assigns(:user)
+    @user.update_attribute(:reset_sent_at, 3.hours.ago)
+    patch password_reset_path(@user.reset_token),
+          params: { email: @user.email,
+                   user: { password:              "foobar",
+                          password_confirmation: "foobar" } }
+    assert_response :redirect
+    follow_redirect!
+    assert_match /expired/i, response.body
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -11,6 +11,8 @@ class UserMailerPreview < ActionMailer::Preview
   # Preview this email at
   # http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -14,10 +14,13 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   test "password_reset" do
-    mail = UserMailer.password_reset
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
     assert_equal "Password reset", mail.subject
-    assert_equal [ "to@example.org" ], mail.to
+    assert_equal [ user.email ], mail.to
     assert_equal [ "noreply@example.com" ], mail.from
-    assert_match "Hi", mail.body.encoded
+    assert_match user.reset_token,        mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
   end
 end


### PR DESCRIPTION
 Chapter 12: Password Reset
- Added password reset functionality
- Implemented password reset email delivery
- Added password reset token and digest to User model
- Set up password reset form and validation
- Added tests for password reset feature

IMAGE EVIDENCE:
Form Login with "forgot password":
![image](https://github.com/user-attachments/assets/1808bce7-5782-4e5b-9da0-b3cb61c47276)
Form for input email to reset:
![image](https://github.com/user-attachments/assets/4caa97f8-8975-402c-a987-74c7e80f3e9a)
Email reset notification sent:
![image](https://github.com/user-attachments/assets/2b879a4f-3dcd-4c6d-82f1-d599429566fd)
Link password reset:
![image](https://github.com/user-attachments/assets/7b0d20c1-cd5f-4345-86ab-25ba3f377b3c)
Form password reset:
![image](https://github.com/user-attachments/assets/eab6cb35-22a1-4c62-bee4-a8acb71ddacc)
Reset error:
![image](https://github.com/user-attachments/assets/77e7a538-1320-4942-aee2-10911f07d23a)
Password reset successfully:
![image](https://github.com/user-attachments/assets/86a2957c-3fe0-4d6e-bf74-84e9941418c1)
